### PR TITLE
Stop following thing when camera jump has been requested

### DIFF
--- a/Source/FollowMe.cs
+++ b/Source/FollowMe.cs
@@ -151,11 +151,11 @@ namespace FollowMe
             _cameraHasJumpedAtLeastOnce = true;
         }
 
+        private static readonly FieldInfo _cameraDriverRootPosField = typeof(CameraDriver).GetField("rootPos", BindingFlags.Instance | BindingFlags.NonPublic);
         private static Vector3 GetRequestedCameraPosition()
         {
             var cameraDriver = Find.CameraDriver;
-            var rootPosField = cameraDriver.GetType().GetField("rootPos", BindingFlags.Instance | BindingFlags.NonPublic);
-            return (Vector3)rootPosField.GetValue(cameraDriver);
+            return (Vector3)_cameraDriverRootPosField.GetValue(cameraDriver);
         }
 
         public static void TryStartFollow( Thing thing )


### PR DESCRIPTION
Resolves #2. Uses reflection on private RimWorld variable; may not be the best way to go about this (although I could not see any other way), but it does at least work.
